### PR TITLE
refactor(jobs): python2 version to stdout

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,14 @@
+name: main
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  main:
+    uses: ./.github/workflows/pre-commit.yml
+    with:
+      python-version: "2.7"

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -26,16 +26,17 @@ jobs:
         with:
           python-version: ${{ inputs.python-version }}
 
-      - name: Set Python 2 version
+      - name: Set Python version
         run: |
-          echo "PY=$(python --version 2>&1)" >> $GITHUB_ENV
-        if: startsWith('${{ inputs.python-version }}', '2')
+          if '${{ startsWith(inputs.python-version, '2')'; then
+            echo "PY=$(python --version 2>&1)" >> $GITHUB_ENV
+          else
+            echo "PY=$(python --version)" >> $GITHUB_ENV
+          fi
 
-      - name: Set Python 3 version
-        run: |
-          echo "PY=$(python --version)" >> $GITHUB_ENV
-        if: startsWith('${{ inputs.python-version }}', '3')
-
-      - name: Test PY
-        run: |
-          echo $PY
+      - name: Cache Python
+        id: cache-python
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.pythonLocation }}
+          key: py-${{ env.PY }}-${{ inputs.image }}

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -38,4 +38,4 @@ jobs:
 
       - name: Test PY
         run: |
-          echo "$PY"
+          echo $PY

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -26,31 +26,16 @@ jobs:
         with:
           python-version: ${{ inputs.python-version }}
 
-      - name: Set Python version
+      - name: Set Python 2 version
+        run: |
+          echo "PY=$(python --version 2>&1)" >> $GITHUB_ENV
+        if: startsWith(${{ inputs.python-version }}, '2')
+
+      - name: Set Python 3 version
         run: |
           echo "PY=$(python --version)" >> $GITHUB_ENV
+        if: startsWith(${{ inputs.python-version }}, '3')
 
-      - name: Cache Python
-        id: cache-python
-        uses: actions/cache@v3
-        with:
-          path: ${{ env.pythonLocation }}
-          key: py-${{ env.PY }}-${{ inputs.image }}
-
-      - name: Install dependencies
+      - name: Test PY
         run: |
-          python -m pip install --upgrade pip pre-commit
-
-      - name: Cache pre-commit
-        uses: actions/cache@v3
-        with:
-          path: ~/.cache/pre-commit
-          key: pre-commit-${{ env.PY }}-${{ inputs.image }}-${{ hashFiles('.pre-commit-config.yaml') }}
-
-      - name: Set skipped pre-commit hooks
-        run: |
-          echo "SKIP=${{ inputs.skip-hooks }}" >> $GITHUB_ENV
-
-      - name: Run pre-commit
-        run: |
-          pre-commit run --all-files --color=always
+          echo "$(PY)"

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -38,4 +38,4 @@ jobs:
 
       - name: Test PY
         run: |
-          echo "$(PY)"
+          echo "$PY"

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Set Python version
         run: |
-          if '${{ startsWith(inputs.python-version, '2')'; then
+          if '${{ startsWith(inputs.python-version, '2') }}'; then
             echo "PY=$(python --version 2>&1)" >> $GITHUB_ENV
           else
             echo "PY=$(python --version)" >> $GITHUB_ENV

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -29,12 +29,12 @@ jobs:
       - name: Set Python 2 version
         run: |
           echo "PY=$(python --version 2>&1)" >> $GITHUB_ENV
-        if: startsWith(${{ inputs.python-version }}, '2')
+        if: startsWith('${{ inputs.python-version }}', '2')
 
       - name: Set Python 3 version
         run: |
           echo "PY=$(python --version)" >> $GITHUB_ENV
-        if: startsWith(${{ inputs.python-version }}, '3')
+        if: startsWith('${{ inputs.python-version }}', '3')
 
       - name: Test PY
         run: |


### PR DESCRIPTION
there is a difference between python3 and python2
this prevents the cache key to have Python 2.7.18