### PR TITLE
refactor(workflows): use ubuntu-20.04 as the default on all workflows

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -4,7 +4,7 @@ on:
       image:
         required: false
         type: string
-        default: ubuntu-22.04
+        default: ubuntu-20.04
       python-version:
         required: false
         type: string

--- a/.github/workflows/tox-envs.yml
+++ b/.github/workflows/tox-envs.yml
@@ -4,7 +4,7 @@ on:
       image:
         required: false
         type: string
-        default: ubuntu-22.04
+        default: ubuntu-20.04
       python-versions:
         required: true
         type: string

--- a/.github/workflows/tox-gh.yml
+++ b/.github/workflows/tox-gh.yml
@@ -4,7 +4,7 @@ on:
       image:
         required: false
         type: string
-        default: ubuntu-22.04
+        default: ubuntu-20.04
       python-versions:
         required: true
         type: string

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -4,7 +4,7 @@ on:
       image:
         required: false
         type: string
-        default: ubuntu-22.04
+        default: ubuntu-20.04
       pre-commit:
         required: false
         type: boolean


### PR DESCRIPTION
ubuntu-20.04 gives us more Python options

BREAKING CHANGE: replace the default runner image