### PR TITLE
refactor: discard unused inputs

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,53 +1,29 @@
 on:
   workflow_call:
     inputs:
-      cache:
-        description: Whether to enable caching.
-        required: false
-        type: boolean
-        default: true
-      image:
-        description: The type of machine to run the job on.
-        required: false
-        type: string
-        default: ubuntu-latest
-      python-version:
-        description: Version of Python to use.
-        required: false
-        type: string
-        default: '3.11'
       skip-hooks:
         required: false
         type: string
         default: ''
-      timeout:
-        description: >-
-          The maximum number of minutes to let a job run before GitHub
-          automatically cancels it.
-        required: false
-        type: number
-        default: 15
 
 jobs:
   pre-commit:
-    runs-on: ${{ inputs.image }}
-    timeout-minutes: ${{ inputs.timeout }}
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
 
-      - name: Set up Python ${{ inputs.python-version }}
+      - name: Set up Python
         uses: actions/setup-python@v4
         id: setup-python
         with:
-          python-version: ${{ inputs.python-version }}
+          python-version: '3.11'
 
       - name: Cache pip
-        if: ${{ inputs.cache == true }}
         uses: actions/cache@v3
         with:
           path: ~/.cache/pip
-          key: pip-pre-commit-${{ steps.setup-python.outputs.python-version }}-${{ inputs.image }}
+          key: pip-pre-commit-${{ steps.setup-python.outputs.python-version }}-${{ runner.os }}
 
       - name: Upgrade pre-installed dependencies
         run: |
@@ -61,11 +37,10 @@ jobs:
           python -m pip install --upgrade pre-commit
 
       - name: Cache pre-commit
-        if: ${{ inputs.cache == true }}
         uses: actions/cache@v3
         with:
           path: ~/.cache/pre-commit
-          key: pre-commit-${{ steps.setup-python.outputs.python-version }}-${{ inputs.image }}-${{ hashFiles('.pre-commit-config.yaml') }}
+          key: pre-commit-${{ steps.setup-python.outputs.python-version }}-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
 
       - name: Run pre-commit
         env:

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,49 +1,24 @@
 on:
   workflow_call:
-    inputs:
-      cache:
-        description: Whether to enable caching.
-        required: false
-        type: boolean
-        default: true
-      image:
-        description: The type of machine to run the job on.
-        required: false
-        type: string
-        default: ubuntu-latest
-      python-version:
-        description: Version of Python to use.
-        required: false
-        type: string
-        default: '3.11'
-      timeout:
-        description: >-
-          The maximum number of minutes to let a job run before GitHub
-          automatically cancels it.
-        required: false
-        type: number
-        default: 15
 
 jobs:
   pylint:
-    runs-on: ${{ inputs.image }}
-    timeout-minutes: ${{ inputs.timeout }}
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
 
-      - name: Set up Python ${{ inputs.python-version }}
+      - name: Set up Python
         uses: actions/setup-python@v4
         id: setup-python
         with:
-          python-version: ${{ inputs.python-version }}
+          python-version: '3.11'
 
       - name: Cache pip
-        if: ${{ inputs.cache == true }}
         uses: actions/cache@v3
         with:
           path: ~/.cache/pip
-          key: pip-pylint-${{ steps.setup-python.outputs.python-version }}-${{ inputs.image }}
+          key: pip-pylint-${{ steps.setup-python.outputs.python-version }}-${{ runner.os }}
 
       - name: Upgrade pre-installed dependencies
         run: |

--- a/.github/workflows/pypi-upload.yml
+++ b/.github/workflows/pypi-upload.yml
@@ -1,11 +1,6 @@
 on:
   workflow_call:
     inputs:
-      image:
-        description: The type of machine to run the job on.
-        required: false
-        type: string
-        default: ubuntu-latest
       python-version:
         description: Version of Python to use.
         required: false
@@ -28,13 +23,6 @@ on:
         required: false
         type: string
         default: '__token__'
-      timeout:
-        description: >-
-          The maximum number of minutes to let a job run before GitHub
-          automatically cancels it.
-        required: false
-        type: number
-        default: 15
     secrets:
       password:
         description: >-
@@ -43,8 +31,7 @@ on:
 
 jobs:
   upload:
-    runs-on: ${{ inputs.image }}
-    timeout-minutes: ${{ inputs.timeout }}
+    runs-on: ubuntu-22.04
     container:
       image: python:${{ inputs.python-version }}-slim
       env:

--- a/.github/workflows/tox-docker.yml
+++ b/.github/workflows/tox-docker.yml
@@ -1,29 +1,10 @@
 on:
   workflow_call:
-    inputs:
-      cache:
-        description: Whether to enable caching.
-        required: false
-        type: boolean
-        default: true
-      image:
-        description: The type of machine to run the job on.
-        required: false
-        type: string
-        default: ubuntu-latest
-      timeout:
-        description: >-
-          The maximum number of minutes to let a job run before GitHub
-          automatically cancels it.
-        required: false
-        type: number
-        default: 15
 
 jobs:
   tox:
-    runs-on: ${{ inputs.image }}
+    runs-on: ubuntu-22.04
     container: coatldev/six:3.11
-    timeout-minutes: ${{ inputs.timeout }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -41,15 +22,14 @@ jobs:
 
       - name: Set PY
         run: |
-          echo "PY=$(python -VV | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
+          echo "PY=$(python --version | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
 
       - name: Cache tox
-        if: ${{ inputs.cache == true }}
         id: cache-tox
         uses: actions/cache@v3
         with:
           path: .tox
-          key: tox-${{ env.PY }}-${{ inputs.image }}-${{ hashFiles('tox.ini') }}
+          key: tox-${{ env.PY }}-${{ runner.os }}-${{ hashFiles('tox.ini') }}
 
       - name: Run tests
         run: |

--- a/.github/workflows/tox-envs.yml
+++ b/.github/workflows/tox-envs.yml
@@ -1,33 +1,15 @@
 on:
   workflow_call:
     inputs:
-      cache:
-        description: Whether to enable caching.
-        required: false
-        type: boolean
-        default: true
-      image:
-        description: The type of machine to run the job on.
-        required: false
-        type: string
-        default: ubuntu-latest
       python-versions:
         description: A list of Python versions.
         required: true
         type: string
-      timeout:
-        description: >-
-          The maximum number of minutes to let a job run before GitHub
-          automatically cancels it.
-        required: false
-        type: number
-        default: 15
 
 jobs:
   tox:
-    name: tox-${{ matrix.python-version }}-${{ inputs.image }}
-    runs-on: ${{ inputs.image }}
-    timeout-minutes: ${{ inputs.timeout }}
+    name: tox-${{ matrix.python-version }}
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         python-version: ${{ fromJSON(inputs.python-versions) }}
@@ -43,12 +25,11 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Cache Python
-        if: ${{ inputs.cache == true }}
         id: cache-python
         uses: actions/cache@v3
         with:
-          path: ${{ env.pythonLocation }}
-          key: py-${{ steps.setup-python.outputs.python-version }}-${{ inputs.image }}
+          path: ${{ steps.setup-python.outputs.python-path }}
+          key: py-${{ steps.setup-python.outputs.python-version }}-${{ runner.os }}
 
       - name: Upgrade pre-installed dependencies
         run: |
@@ -71,12 +52,11 @@ jobs:
         shell: python
 
       - name: Cache tox
-        if: ${{ inputs.cache == true }}
         id: cache-tox
         uses: actions/cache@v3
         with:
           path: .tox
-          key: tox-envs-${{ steps.setup-python.outputs.python-version }}-${{ inputs.image }}-${{ hashFiles('tox.ini') }}
+          key: tox-envs-${{ steps.setup-python.outputs.python-version }}-${{ runner.os }}-${{ hashFiles('tox.ini') }}
 
       - name: Run tox
         run: |

--- a/.github/workflows/tox-gh.yml
+++ b/.github/workflows/tox-gh.yml
@@ -1,33 +1,15 @@
 on:
   workflow_call:
     inputs:
-      cache:
-        description: Whether to enable caching.
-        required: false
-        type: boolean
-        default: true
-      image:
-        description: The type of machine to run the job on.
-        required: false
-        type: string
-        default: ubuntu-latest
       python-versions:
         description: A list of Python versions.
         required: true
         type: string
-      timeout:
-        description: >-
-          The maximum number of minutes to let a job run before GitHub
-          automatically cancels it.
-        required: false
-        type: number
-        default: 15
 
 jobs:
   tox:
-    name: tox-${{ matrix.python-version }}-${{ inputs.image }}
-    runs-on: ${{ inputs.image }}
-    timeout-minutes: ${{ inputs.timeout }}
+    name: tox-${{ matrix.python-version }}
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         python-version: ${{ fromJSON(inputs.python-versions) }}
@@ -43,12 +25,11 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Cache Python
-        if: ${{ inputs.cache == true }}
         id: cache-python
         uses: actions/cache@v3
         with:
-          path: ${{ env.pythonLocation }}
-          key: py-${{ steps.setup-python.outputs.python-version }}-${{ inputs.image }}
+          path: ${{ steps.setup-python.outputs.python-path }}
+          key: py-${{ steps.setup-python.outputs.python-version }}-${{ runner.os }}
 
       - name: Upgrade pre-installed dependencies
         run: |
@@ -62,12 +43,11 @@ jobs:
           python -m pip install --upgrade tox-gh
 
       - name: Cache tox
-        if: ${{ inputs.cache == true }}
         id: cache-tox
         uses: actions/cache@v3
         with:
           path: .tox
-          key: tox-gh-${{ steps.setup-python.outputs.python-version }}-${{ inputs.image }}-${{ hashFiles('tox.ini') }}
+          key: tox-gh-${{ steps.setup-python.outputs.python-version }}-${{ runner.os }}-${{ hashFiles('tox.ini') }}
 
       - name: Run tox
         run: |

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -1,49 +1,24 @@
 on:
   workflow_call:
-    inputs:
-      cache:
-        description: Whether to enable caching.
-        required: false
-        type: boolean
-        default: true
-      image:
-        description: The type of machine to run the job on.
-        required: false
-        type: string
-        default: ubuntu-latest
-      python-version:
-        description: Version of Python to use.
-        required: false
-        type: string
-        default: '3.11'
-      timeout:
-        description: >-
-          The maximum number of minutes to let a job run before GitHub
-          automatically cancels it.
-        required: false
-        type: number
-        default: 15
 
 jobs:
   tox:
-    runs-on: ${{ inputs.image }}
-    timeout-minutes: ${{ inputs.timeout }}
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
 
-      - name: Set up Python ${{ inputs.python-version }}
+      - name: Set up Python
         uses: actions/setup-python@v4
         id: setup-python
         with:
-          python-version: ${{ inputs.python-version }}
+          python-version: '3.11'
 
       - name: Cache pip
-        if: ${{ inputs.cache == true }}
         uses: actions/cache@v3
         with:
           path: ~/.cache/pip
-          key: pip-tox-${{ steps.setup-python.outputs.python-version }}-${{ inputs.image }}
+          key: pip-tox-${{ steps.setup-python.outputs.python-version }}-${{ runner.os }}
 
       - name: Upgrade pre-installed dependencies
         run: |
@@ -57,12 +32,11 @@ jobs:
           python -m pip install --upgrade tox
 
       - name: Cache tox
-        if: ${{ inputs.cache == true }}
         id: cache-tox
         uses: actions/cache@v3
         with:
           path: .tox
-          key: tox-${{ steps.setup-python.outputs.python-version }}-${{ inputs.image }}-${{ hashFiles('tox.ini') }}
+          key: tox-${{ steps.setup-python.outputs.python-version }}-${{ runner.os }}-${{ hashFiles('tox.ini') }}
 
       - name: Run tests
         run: |


### PR DESCRIPTION
BREAKING CHANGE: drop unused inputs and set Python 3.11 and ubuntu-22.04 as default