### PR TITLE
refactor: use Python 3.12 as default version

### DIFF
--- a/.github/workflows/pip-compile-upgrade.yml
+++ b/.github/workflows/pip-compile-upgrade.yml
@@ -11,7 +11,7 @@ on:
           Python version to use for installing pip-tools.
         required: false
         type: string
-        default: '2.7'
+        default: '3.12'
       pr-create:
         description: >-
           Whether to create a Pull Request.
@@ -77,12 +77,22 @@ jobs:
           passphrase: ${{ secrets.gpg-sign-passphrase }}
           private-key: ${{ secrets.gpg-sign-private-key }}
 
+      - name: Build commit message
+        if: ${{ steps.git-diff.outputs.diff == 'true' }}
+        run: |
+          echo "${{ inputs.pr-commit-message }}" > "$RUNNER_TEMP/commit.txt"
+          {
+              echo ""
+              echo "updates:"
+              git status --porcelain | awk 'match($1, "M") {print "  - " $2}'
+          } >> "$RUNNER_TEMP/commit.txt"
+
       - name: Commit and push changes
         if: ${{ steps.git-diff.outputs.diff == 'true' && inputs.pr-create == 'yes' }}
         run: |
           git checkout -B coatl-dev-pip-compile-upgrade
           git add ${{ inputs.path }}
-          git commit -m "${{ inputs.pr-commit-message }}"
+          git commit --file="${RUNNER_TEMP}/commit.txt"
           git push --force --set-upstream origin coatl-dev-pip-compile-upgrade
 
       - name: Create pull request

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -44,11 +44,11 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
 
-      - name: Set up Python 3.11
+      - name: Set up Python
         uses: actions/setup-python@v5
         id: setup-python
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/setup-python@v5
         id: setup-python
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/setup-python@v5
         id: setup-python
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/.github/workflows/pypi-upload.yml
+++ b/.github/workflows/pypi-upload.yml
@@ -5,7 +5,7 @@ on:
         description: Version of Python to use.
         required: false
         type: string
-        default: '3.11'
+        default: '3.12'
       check:
         description: Check metadata with twine before uploading.
         required: false

--- a/.github/workflows/tox-docker.yml
+++ b/.github/workflows/tox-docker.yml
@@ -1,10 +1,17 @@
 on:
   workflow_call:
+    inputs:
+      python-version:
+        description: >-
+          Python version to use for installing pip-tools.
+        required: false
+        type: string
+        default: '3.12'
 
 jobs:
   tox:
     runs-on: ubuntu-22.04
-    container: coatldev/six:3.11
+    container: coatldev/six:${{ inputs.python-version }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/setup-python@v5
         id: setup-python
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ requirements.
 
 - `path` (`string`): A file or location of the requirement file(s).
 - `python-version` (`string`): Python version to use for installing `pip-tools`.
-  You may use MAJOR.MINOR or exact version. Defaults to `'2.7'`. Optional.
+  You may use MAJOR.MINOR or exact version. Defaults to `'3.12'`. Optional.
 - `pr-create` (`string`): Whether to create a Pull Request. Options: `'yes'`,
   `'no'`. Defaults to `'yes'`. Optional.
 - `pr-commit-message` (`string`): Use the given message as the commit message.
@@ -160,7 +160,7 @@ PyPI (or any other repository) using `build` and `twine`.
 
 - `python-version` (`string`): The Python version to use for building and
   publishing the package. You may use MAJOR.MINOR or exact version. Defaults to
-  `'3.11'`. Optional
+  `'3.12'`. Optional
 - `check` (`boolean`): Check metadata with twine before uploading. Defaults to
   `true`. Optional.
 - `url` (`string`): The repository (package index) URL to upload the package to.
@@ -190,10 +190,16 @@ jobs:
 This workflow will install the latest version of `tox` to run all envs found in
 [`env_list`].
 
+**Inputs**:
+
+- `python-version` (`string`): The Python version to use for building and
+  publishing the package. You may use MAJOR.MINOR or exact version. Defaults to
+  `'3.12'`. Optional
+
 **Notes**:
 
-- This workflow uses the [`coatldev/six:3.11`] Docker image, which comes with
-  Python 2.7 and 3.11.
+- This workflow uses the [`coatldev/six:3.12`] Docker image, which comes with
+  Python 2.7 and 3.12.
 
 **Example**:
 
@@ -296,7 +302,7 @@ jobs:
 ```
 
 [`actions/setup-python`]: https://github.com/actions/setup-python
-[`coatldev/six:3.11`]: https://hub.docker.com/r/coatldev/six
+[`coatldev/six:3.12`]: https://hub.docker.com/r/coatldev/six
 [`env_list`]: https://tox.wiki/en/latest/config.html#env_list
 [`local hooks`]: https://pre-commit.com/#repository-local-hooks
 [`pre-commit`]: https://pre-commit.com/


### PR DESCRIPTION
BREAKING CHANGE: replace Python 2.7 and 3.11 with 3.12 as default