### PR TITLE
fix(docker-build): remove set up qemu action

### DIFF
--- a/.github/workflows/docker-build-push-multi-platform.yml
+++ b/.github/workflows/docker-build-push-multi-platform.yml
@@ -80,9 +80,6 @@ jobs:
           images: |
             ${{ inputs.registry-image }}
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 


### PR DESCRIPTION
with ubuntu-24.04-arm there's no need for qemu
