### PR TITLE
fix(tox-docker): add $HOME/.local/bin to $PATH

### DIFF
--- a/.github/workflows/tox-docker.yml
+++ b/.github/workflows/tox-docker.yml
@@ -52,6 +52,10 @@ jobs:
           path: ${{ steps.setup-tox.outputs.tox-cache-dir }}
           key: tox-${{ env.UV_PYTHON }}-${{ runner.os }}-${{ hashFiles(steps.setup-tox.outputs.tox-ini) }}
 
+      - name: Add ~/.local/bin to PATH
+        run: |
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
       - name: Run tests
         working-directory: ${{ inputs.working-directory }}
         run: |


### PR DESCRIPTION
uv installs tools at .local/bin directory of the user's home directory
