### PR TITLE
refactor: use coatl-dev/actions@v7.0.0

### DIFF
--- a/.github/workflows/pip-compile-upgrade.yml
+++ b/.github/workflows/pip-compile-upgrade.yml
@@ -1,15 +1,16 @@
 on:
   workflow_call:
     inputs:
+      base-branch:
+        description: >-
+          The branch to use as the base for the PR.
+        required: false
+        type: string
+        default: ''
       checkout-ref:
         description: >-
           The branch, tag or SHA to checkout.
         required: false
-        type: string
-      path:
-        description: >-
-          The location of the requirement file(s).
-        required: true
         type: string
       extra-args:
         description: >-
@@ -17,52 +18,45 @@ on:
         required: false
         type: string
         default: ''
-      working-directory:
+      path:
         description: >-
-          The directory to run the workflow in.
-        required: false
+          The location of the requirement file(s).
+        required: true
         type: string
-        default: ${{ github.workspace }}
-      pr-create:
-        description: >-
-          Whether to create a Pull Request.
-        required: false
-        type: string
-        default: 'yes'
-      pr-commit-message:
-        description: >-
-          Use the given <msg> as the commit message.
-        required: false
-        type: string
-        default: 'chore(requirements): pip-compile upgrade'
       pr-auto-merge:
         description: >-
           Automatically merge only after necessary requirements are met.
         required: false
         type: string
         default: 'yes'
-      pr-delete-branch:
-        description: >-
-          Delete the local and remote branch after merge.
-        required: false
-        type: string
-        default: 'no'
-      pr-create-additional-args:
-        description: >-
-          Additional arguments to pass to the gh pr create command.
-        required: false
-        type: string
-        default: ''
       pr-branch:
         description: >-
           The branch to use for the submitting the PR.
         type: string
         required: false
         default: 'coatl-dev-pip-compile-upgrade'
+      pr-commit-message:
+        description: >-
+          Use the given <msg> as the commit message.
+        required: false
+        type: string
+        default: 'chore(requirements): pip-compile upgrade'
+      pr-delete-branch:
+        description: >-
+          Delete the local and remote branch after merge.
+        required: false
+        type: string
+        default: 'no'
       sign-commits:
         required: false
         type: string
         default: 'yes'
+      working-directory:
+        description: >-
+          The directory to run the workflow in.
+        required: false
+        type: string
+        default: ${{ github.workspace }}
     secrets:
       gh-token:
         description: >-
@@ -128,7 +122,7 @@ jobs:
           path: ${{ inputs.path }}
 
       - name: Import GPG key
-        if: ${{ steps.git-diff.outputs.diff == 'true' && inputs.pr-create == 'yes' && inputs.sign-commits == 'yes' }}
+        if: ${{ steps.git-diff.outputs.diff == 'true' && inputs.sign-commits == 'yes' }}
         id: gpg-import
         uses: coatl-dev/actions/gpg-import@ed363d0af5aeaadc047db4bdebbdd81d916c2e7d # v6.0.0
         with:
@@ -146,18 +140,18 @@ jobs:
           } >> "$RUNNER_TEMP/commit.txt"
 
       - name: Commit and push changes
-        if: ${{ steps.git-diff.outputs.diff == 'true' && inputs.pr-create == 'yes' }}
+        if: ${{ steps.git-diff.outputs.diff == 'true' }}
         run: |
           git checkout -B ${{ inputs.pr-branch }}
           git add ${{ inputs.path }}
           git commit --file="${RUNNER_TEMP}/commit.txt"
           git push --force --set-upstream origin ${{ inputs.pr-branch }}
 
-      - name: Create pull request
-        if: ${{ steps.git-diff.outputs.diff == 'true' && inputs.pr-create == 'yes' }}
-        uses: coatl-dev/actions/pr-create@ed363d0af5aeaadc047db4bdebbdd81d916c2e7d # v6.0.0
+      - name: Create Pull Request
+        if: ${{ steps.git-diff.outputs.diff == 'true' }}
+        uses: coatl-dev/actions/pr-create@208567f6e604baf94c6e867ec7f345ec9ad36eb4 # v7.0.0
         with:
           gh-token: ${{ secrets.gh-token }}
           auto-merge: ${{ inputs.pr-auto-merge }}
+          base-branch: ${{ inputs.base-branch }}
           delete-branch: ${{ inputs.pr-delete-branch }}
-          additional-args: ${{ inputs.pr-create-additional-args }}

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -1,35 +1,35 @@
 on:
   workflow_call:
     inputs:
+      autoupdate-branch:
+        description: >-
+          The branch to use for autoupdate.
+        type: string
+        required: false
+        default: ''
       checkout-ref:
         description: >-
           The branch, tag or SHA to checkout.
         required: false
         type: string
-      pr-create:
-        description: >-
-          Whether to create a Pull Request.
-        required: false
-        type: string
-        default: 'yes'
       pr-auto-merge:
         description: >-
           Automatically merge only after necessary requirements are met.
         required: false
         type: string
         default: 'yes'
+      pr-branch:
+        description: >-
+          The branch to use for autoupdate.
+        type: string
+        required: false
+        default: 'coatl-dev-pre-commit-autoupdate'
       pr-delete-branch:
         description: >-
           Delete the local and remote branch after merge.
         required: false
         type: string
         default: 'no'
-      pr-create-additional-args:
-        description: >-
-          Additional arguments to pass to the gh pr create command.
-        required: false
-        type: string
-        default: ''
       sign-commits:
         required: false
         type: string
@@ -39,12 +39,6 @@ on:
           A list of repos to exclude from autoupdate.
         type: string
         required: false
-      pr-branch:
-        description: >-
-          The branch to use for autoupdate.
-        type: string
-        required: false
-        default: 'coatl-dev-pre-commit-autoupdate'
     secrets:
       gh-token:
         description: >-
@@ -117,7 +111,7 @@ jobs:
           path: .pre-commit-config.yaml
 
       - name: Import GPG key
-        if: ${{ steps.git-diff.outputs.diff == 'true' && inputs.pr-create == 'yes' && inputs.sign-commits == 'yes' }}
+        if: ${{ steps.git-diff.outputs.diff == 'true' && inputs.sign-commits == 'yes' }}
         id: gpg-import
         uses: coatl-dev/actions/gpg-import@ed363d0af5aeaadc047db4bdebbdd81d916c2e7d # v6.0.0
         with:
@@ -136,7 +130,7 @@ jobs:
           } >> "$RUNNER_TEMP/commit.txt"
 
       - name: Commit and push changes
-        if: ${{ steps.git-diff.outputs.diff == 'true' && inputs.pr-create == 'yes' }}
+        if: ${{ steps.git-diff.outputs.diff == 'true' }}
         run: |
           git checkout -B ${{ inputs.pr-branch }}
           git add .pre-commit-config.yaml
@@ -144,10 +138,10 @@ jobs:
           git push --force --set-upstream origin ${{ inputs.pr-branch }}
 
       - name: Create Pull Request
-        if: ${{ steps.git-diff.outputs.diff == 'true' && inputs.pr-create == 'yes' }}
-        uses: coatl-dev/actions/pr-create@ed363d0af5aeaadc047db4bdebbdd81d916c2e7d # v6.0.0
+        if: ${{ steps.git-diff.outputs.diff == 'true' }}
+        uses: coatl-dev/actions/pr-create@208567f6e604baf94c6e867ec7f345ec9ad36eb4 # v7.0.0
         with:
           gh-token: ${{ secrets.gh-token }}
           auto-merge: ${{ inputs.pr-auto-merge }}
+          base-branch: ${{ inputs.autoupdate-branch }}
           delete-branch: ${{ inputs.pr-delete-branch }}
-          additional-args: ${{ inputs.pr-create-additional-args }}

--- a/.github/workflows/uv-pip-compile-upgrade.yml
+++ b/.github/workflows/uv-pip-compile-upgrade.yml
@@ -1,6 +1,12 @@
 on:
   workflow_call:
     inputs:
+      base-branch:
+        description: >-
+          The branch to use as the base for the PR.
+        required: false
+        type: string
+        default: ''
       checkout-ref:
         description: >-
           The branch, tag or SHA to checkout.
@@ -11,58 +17,46 @@ on:
           The location of the requirement file(s).
         required: true
         type: string
-      python-version:
-        description: >-
-          The version of Python to set UV_PYTHON to.
-        required: false
-        type: string
-        default: '3.14'
-      working-directory:
-        description: >-
-          The directory to run the workflow in.
-        required: false
-        type: string
-        default: ${{ github.workspace }}
-      pr-create:
-        description: >-
-          Whether to create a Pull Request.
-        required: false
-        type: string
-        default: 'yes'
-      pr-commit-message:
-        description: >-
-          Use the given <msg> as the commit message.
-        required: false
-        type: string
-        default: 'chore(requirements): uv pip compile upgrade'
       pr-auto-merge:
         description: >-
           Automatically merge only after necessary requirements are met.
         required: false
         type: string
         default: 'yes'
-      pr-delete-branch:
-        description: >-
-          Delete the local and remote branch after merge.
-        required: false
-        type: string
-        default: 'no'
-      pr-create-additional-args:
-        description: >-
-          Additional arguments to pass to the gh pr create command.
-        required: false
-        type: string
-        default: ''
       pr-branch:
         description: >-
           The branch to use for the submitting the PR.
         type: string
         required: false
         default: 'coatl-dev-pip-compile-upgrade'
+      pr-commit-message:
+        description: >-
+          Use the given <msg> as the commit message.
+        required: false
+        type: string
+        default: 'chore(requirements): uv pip compile upgrade'
+      pr-delete-branch:
+        description: >-
+          Delete the local and remote branch after merge.
+        required: false
+        type: string
+        default: 'no'
+      python-version:
+        description: >-
+          The version of Python to set UV_PYTHON to.
+        required: false
+        type: string
+        default: '3.14'
       sign-commits:
         required: false
         type: string
         default: 'yes'
+      working-directory:
+        description: >-
+          The directory to run the workflow in.
+        required: false
+        type: string
+        default: ${{ github.workspace }}
     secrets:
       gh-token:
         description: >-
@@ -102,7 +96,7 @@ jobs:
           path: ${{ inputs.path }}
 
       - name: Import GPG key
-        if: ${{ steps.git-diff.outputs.diff == 'true' && inputs.pr-create == 'yes' && inputs.sign-commits == 'yes' }}
+        if: ${{ steps.git-diff.outputs.diff == 'true' && inputs.sign-commits == 'yes' }}
         id: gpg-import
         uses: coatl-dev/actions/gpg-import@ed363d0af5aeaadc047db4bdebbdd81d916c2e7d # v6.0.0
         with:
@@ -120,18 +114,18 @@ jobs:
           } >> "$RUNNER_TEMP/commit.txt"
 
       - name: Commit and push changes
-        if: ${{ steps.git-diff.outputs.diff == 'true' && inputs.pr-create == 'yes' }}
+        if: ${{ steps.git-diff.outputs.diff == 'true' }}
         run: |
           git checkout -B ${{ inputs.pr-branch }}
           git add ${{ inputs.path }}
           git commit --file="${RUNNER_TEMP}/commit.txt"
           git push --force --set-upstream origin ${{ inputs.pr-branch }}
 
-      - name: Create pull request
-        if: ${{ steps.git-diff.outputs.diff == 'true' && inputs.pr-create == 'yes' }}
-        uses: coatl-dev/actions/pr-create@ed363d0af5aeaadc047db4bdebbdd81d916c2e7d # v6.0.0
+      - name: Create Pull Request
+        if: ${{ steps.git-diff.outputs.diff == 'true' }}
+        uses: coatl-dev/actions/pr-create@208567f6e604baf94c6e867ec7f345ec9ad36eb4 # v7.0.0
         with:
           gh-token: ${{ secrets.gh-token }}
           auto-merge: ${{ inputs.pr-auto-merge }}
+          base-branch: ${{ inputs.base-branch }}
           delete-branch: ${{ inputs.pr-delete-branch }}
-          additional-args: ${{ inputs.pr-create-additional-args }}

--- a/README.md
+++ b/README.md
@@ -134,22 +134,19 @@ GitHub action for running `pip-compile upgrade` on your Python 2.7 requirements.
 
 **Inputs**:
 
+- `base-branch` (`string`): The branch to use as the base for the PR.
 - `checkout-ref` (`string`): The branch, tag or SHA to checkout. Optional.
-- `path` (`string`): The location of the requirement file(s).
 - `extra-args` (`string`): Extra arguments to pass to `pip-compile`. Optional.
   Defaults to `''`.
-- `pr-create` (`string`): Whether to create a Pull Request. Options: `'yes'`,
-  `'no'`. Defaults to `'yes'`. Optional.
-- `pr-commit-message` (`string`): Use the given message as the commit message.
-  Defaults to `'chore(requirements): pip-compile upgrade'`. Optional.
+- `path` (`string`): The location of the requirement file(s).
 - `pr-auto-merge` (`string`): Automatically merge only after necessary
   requirements are met. Options: `'yes'`, `'no'`. Defaults to `'yes'`. Optional.
-- `pr-delete-branch` (`string`): Delete the local and remote branch after merge.
-  Options: `'yes'`, `'no'`. Defaults to `'no'`. Optional.
-- `pr-create-additional-args` (`string`): Additional arguments to pass to the
-  `gh pr create` command. Defaults to `''`. Optional.
 - `pr-branch` (`string`): The branch to use for the submitting the PR. Defaults
   to `'coatl-dev-pip-compile-upgrade'`. Optional.
+- `pr-commit-message` (`string`): Use the given message as the commit message.
+  Defaults to `'chore(requirements): pip-compile upgrade'`. Optional.
+- `pr-delete-branch` (`string`): Delete the local and remote branch after merge.
+  Options: `'yes'`, `'no'`. Defaults to `'no'`. Optional.
 - `sign-commits` (`string`): Whether to sign Git commits. Options: `'yes'`,
   `'no'`. Defaults to `'yes'`. Optional.
 - `working-directory` (`string`): The directory to run the workflow in.
@@ -193,20 +190,15 @@ to install Python and invoke [`pre-commit autoupdate`].
 
 **Inputs**:
 
+- `autoupdate-branch` (`string`): branch to send autoupdate PRs to. By default,
+  this will update the default branch of the repository.
 - `checkout-ref` (`string`): The branch, tag or SHA to checkout. Optional.
-- `pr-base-branch` (`string`): The branch into which you want your code merged.
-  Defaults to `'main'`. Required when `pr-create` is set to `'yes'`, otherwise
-  is optional.
-- `pr-create` (`string`): Whether to create a Pull Request. Options: `'yes'`,
-  `'no'`. Defaults to `'yes'`. Optional.
 - `pr-auto-merge` (`string`): Automatically merge only after necessary
   requirements are met. Options: `'yes'`, `'no'`. Defaults to `'yes'`. Optional.
-- `pr-delete-branch` (`string`): Delete the local and remote branch after merge.
-  Options: `'yes'`, `'no'`. Defaults to `'no'`. Optional.
-- `pr-create-additional-args` (`string`): Additional arguments to pass to the
-  `gh pr create` command. Defaults to `''`. Optional.
 - `pr-branch` (`string`): The branch to use for autoupdate. Defaults to
   `'coatl-dev-pre-commit-autoupdate'`. Optional.
+- `pr-delete-branch` (`string`): Delete the local and remote branch after merge.
+  Options: `'yes'`, `'no'`. Defaults to `'no'`. Optional.
 - `sign-commits` (`string`): Whether to sign Git commits. Options: `'yes'`,
   `'no'`. Defaults to `'yes'`. Optional.
 - `skip-repos` (`string`): A list of repos to exclude from autoupdate. The repos
@@ -236,7 +228,7 @@ jobs:
     uses: coatl-dev/workflows/.github/workflows/pre-commit-autoupdate.yml@v6.2.5
     with:
       skip-repos: 'flake8'
-      pr-create-additional-args: other
+      autoupdate-branch: 'develop'
     secrets:
       gh-token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
       gpg-sign-passphrase: ${{ secrets.GPG_PASSPHRASE }}
@@ -245,8 +237,8 @@ jobs:
 
 ### .github/workflows/pre-commit.yml
 
-If you [cannot/do not want to] benefit from [`pre-commit.ci`], use this workflow
-to install Python and invoke [`pre-commit`].
+This workflow will install Python and invoke `pre-commit` to run hooks on all
+the files in the repo.
 
 **Inputs**:
 
@@ -458,23 +450,20 @@ requirements.
 
 **Inputs**:
 
+- `base-branch` (`string`): The branch to use as the base for the PR.
 - `checkout-ref` (`string`): The branch, tag or SHA to checkout. Optional.
 - `path` (`string`): The location of the requirement file(s).
+- `pr-auto-merge` (`string`): Automatically merge only after necessary
+  requirements are met. Options: `'yes'`, `'no'`. Defaults to `'yes'`. Optional.
+- `pr-branch` (`string`): The branch to use for the submitting the PR. Defaults
+  to `'coatl-dev-pip-compile-upgrade'`. Optional.
+- `pr-commit-message` (`string`): Use the given message as the commit message.
+  Defaults to `'chore(requirements): pip-compile upgrade'`. Optional.
+- `pr-delete-branch` (`string`): Delete the local and remote branch after merge.
+  Options: `'yes'`, `'no'`. Defaults to `'no'`. Optional.
 - `python-version` (`string`): The version of Python to set `UV_PYTHON` to. You
   may use MAJOR.MINOR or exact version. Options: `'3.8'` to `'3.14'`. Defaults
   to `'3.14'`. Optional.
-- `pr-create` (`string`): Whether to create a Pull Request. Options: `'yes'`,
-  `'no'`. Defaults to `'yes'`. Optional.
-- `pr-commit-message` (`string`): Use the given message as the commit message.
-  Defaults to `'chore(requirements): pip-compile upgrade'`. Optional.
-- `pr-auto-merge` (`string`): Automatically merge only after necessary
-  requirements are met. Options: `'yes'`, `'no'`. Defaults to `'yes'`. Optional.
-- `pr-delete-branch` (`string`): Delete the local and remote branch after merge.
-  Options: `'yes'`, `'no'`. Defaults to `'no'`. Optional.
-- `pr-create-additional-args` (`string`): Additional arguments to pass to the
-  `gh pr create` command. Defaults to `''`. Optional.
-- `pr-branch` (`string`): The branch to use for the submitting the PR. Defaults
-  to `'coatl-dev-pip-compile-upgrade'`. Optional.
 - `sign-commits` (`string`): Whether to sign Git commits. Options: `'yes'`,
   `'no'`. Defaults to `'yes'`. Optional.
 - `working-directory` (`string`): The directory to run the workflow in.


### PR DESCRIPTION
update workflows where pr-create action was referenced

BREAKING CHANGE: drop pr-create input; a PR will always be created
